### PR TITLE
Bbl 33 billing review

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,56 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .MergeCommits -}}
+### Pull Requests
+{{ range .MergeCommits -}}
+- {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,28 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/binbashar/public-docker-images
+options:
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
+  commit_groups:
+    # title_maps:
+    #   feat: Features
+    #   fix: Bug Fixes
+    #   perf: Performance Improvements
+    #   refactor: Code Refactoring
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !*.dockeringnore
 !*.hosts
 !/.gitignore
+!/.chglog
 !*.gitkeep
 
 # OS generated files #

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+.PHONY: help
+SHELL := /bin/bash
+LOCAL_OS_USER := $(shell whoami)
+LOCAL_OS_SSH_DIR := ~/.ssh
+LOCAL_OS_GIT_CONF_DIR := ~/.gitconfig
+
+PWD_DIR := $(shell pwd)
+
+# pre-req -> https://github.com/pnikosis/semtag
+define GIT_SEMTAG_CMD_PREFIX
+docker run --rm \
+-v ${PWD_DIR}:/data:rw \
+-v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
+-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
+--entrypoint=/opt/semtag/semtag/semtag \
+-it binbash/git-release
+endef
+
+GIT_SEMTAG_VER := $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s minor)
+
+help:
+	@echo 'Available Commands:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+release: ## releasing based on semantic tagging script for Git
+	# pre-req -> https://github.com/pnikosis/semtag
+	${GIT_SEMTAG_CMD_PREFIX} --version
+	${GIT_SEMTAG_CMD_PREFIX} get
+	${GIT_SEMTAG_CMD_PREFIX} final -s minor
+
+changelog-init: ## git changelog (https://github.com/git-chglog/git-chglog) config initialization -> ./.chglog
+	@if [ ! -d ./.chglog ]; then\
+		docker run --rm -v ${PWD_DIR}:/data -it binbash/git-release --init;\
+		sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog;\
+    else\
+		echo "==============================";\
+    	echo "git-chglog already initialized";\
+    	echo "==============================";\
+    	echo "$$(ls ./.chglog)";\
+    	echo "==============================";\
+    fi
+
+changelog: ## git changelog (https://github.com/git-chglog/git-chglog)
+	docker run --rm -v ${PWD_DIR}:/data -it binbash/git-release -o CHANGELOG.md --next-tag ${GIT_SEMTAG_VER}
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,5 @@ changelog-init: ## git changelog (https://github.com/git-chglog/git-chglog) conf
 changelog: ## git changelog (https://github.com/git-chglog/git-chglog)
 	docker run --rm -v ${PWD_DIR}:/data -it binbash/git-release -o CHANGELOG.md --next-tag ${GIT_SEMTAG_VER}
 	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./CHANGELOG.md
+

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 
 |Docker Image| Build Status|
 |---|---|
+|`git-release`|[![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/binbash/git-release.svg)](https://cloud.docker.com/u/binbash/repository/docker/binbash/git-release/general) [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/binbash/git-release.svg)](https://cloud.docker.com/u/binbash/repository/docker/binbash/git-release/builds)|
 |`jenkins`|[![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/binbash/jenkins.svg)](https://cloud.docker.com/u/binbash/repository/docker/binbash/jenkins/general) [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/binbash/jenkins.svg)](https://cloud.docker.com/u/binbash/repository/docker/binbash/jenkins/builds)|
 |`mysql-client`|[![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/binbash/mysql-client.svg)](https://cloud.docker.com/u/binbash/repository/docker/binbash/mysql-client/general) [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/binbash/mysql-client.svg)](https://cloud.docker.com/u/binbash/repository/docker/binbash/mysql-client/builds)|
 |`php7.1-composer`|[![Docker Cloud Automated build](https://img.shields.io/docker/cloud/automated/binbash/php7.1-composer.svg)](https://cloud.docker.com/u/binbash/repository/docker/binbash/php7.1-composer/general) [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/binbash/php7.1-composer.svg)](https://cloud.docker.com/u/binbash/repository/docker/binbash/php7.1-composer/builds)|

--- a/git-release/Dockerfile
+++ b/git-release/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.12-stretch
+
+# sources vars
+ARG PACKAGE_PATH_1="github.com/git-chglog/git-chglog/cmd/git-chglog"
+ARG PACKAGE_PATH_2="https://github.com/pnikosis/semtag"
+
+# git-chglog
+RUN apt-get update && apt-get install -y --no-install-recommends git bash
+RUN go get ${PACKAGE_PATH_1}
+
+# semtag
+RUN mkdir /opt/semtag && cd /opt/semtag && git clone ${PACKAGE_PATH_2}
+RUN chmod 755 /opt/semtag/semtag
+
+WORKDIR /data
+ENTRYPOINT ["git-chglog"]

--- a/git-release/Makefile
+++ b/git-release/Makefile
@@ -1,0 +1,24 @@
+.PHONY: build
+DOCKER_TAG = 0.0.1
+DOCKER_IMG_NAME = git-release
+DOCKER_PWD_DIR := $(shell pwd)
+DOCKER_SEMTAG_CMD := /opt/semtag/semtag/semtag
+
+help:
+	@echo 'Available Commands:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+build: ## build docker image
+	docker build -t binbash/${DOCKER_IMG_NAME}:${DOCKER_TAG} -t binbash/${DOCKER_IMG_NAME}:latest .
+
+build-no-cache: ## build docker image no cache
+	docker build --no-cache -t binbash/${DOCKER_IMG_NAME}:${DOCKER_TAG} -t binbash/${DOCKER_IMG_NAME}:latest .
+
+run-git-chglog: ## docker run git-chglog
+	docker run -it --rm -v "${DOCKER_PWD_DIR}:/data" binbash/git-release --version
+
+run-git-semtag: ## docker run semtag
+	docker run -it --rm -v "${DOCKER_PWD_DIR}:/data" --entrypoint=${DOCKER_SEMTAG_CMD} binbash/git-release --version
+
+push: ## push docker image to registry
+	docker push binbash/${DOCKER_IMG_NAME}:${DOCKER_TAG} && docker push binbash/${DOCKER_IMG_NAME}:latest

--- a/git-release/README.md
+++ b/git-release/README.md
@@ -99,7 +99,7 @@ changelog-init: ## git changelog (https://github.com/git-chglog/git-chglog) conf
 		docker run --rm -v ${PWD_DIR}:/data -it binbash/git-release --init;\
 		sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog;\
     else\
-		echo "==============================";\
+        echo "==============================";\
     	echo "git-chglog already initialized";\
     	echo "==============================";\
     	echo "$$(ls ./.chglog)";\
@@ -109,5 +109,5 @@ changelog-init: ## git changelog (https://github.com/git-chglog/git-chglog) conf
 changelog: ## git changelog (https://github.com/git-chglog/git-chglog)
 	docker run --rm -v ${PWD_DIR}:/data -it binbash/git-release -o CHANGELOG.md --next-tag ${GIT_SEMTAG_VER}
 	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog
-    sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./CHANGELOG.md
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./CHANGELOG.md
 ```

--- a/git-release/README.md
+++ b/git-release/README.md
@@ -1,0 +1,112 @@
+# git release automation with git-chglog and semtag
+
+#### git-chglog
+CHANGELOG generator implemented in Go (Golang). Anytime, anywhere, Write your CHANGELOG.
+
+- Official **git-chglog** [documentation available on GitHub project repo](https://github.com/git-chglog/git-chglog).
+
+#### semtag
+Semantic Tagging Script for Git. This is a script to help out version bumping on a project following the Semantic Versioning specification. It uses Git Tags to keep track the versions and the commit log between them, so no extra files are needed. It can be combined with release scripts, git hooks, etc, to have a consistent versioning.
+
+- Official **semtag** [documentation available on GitHub project repo](https://github.com/pnikosis/semtag).
+
+
+## Docker Usage
+
+### git-chglog
+Build the docker image using provided Dockerfile and use it directly:
+
+```bash
+docker run -it --rm -v "$PWD:/data" binbash/git-chglog
+```
+
+Alternatively create an alias in your ~/.bashrc by copying the line below
+
+```bash
+alias git-changelog='docker run -it --rm -v "$PWD:/data" binbash/git-chglog'
+```
+
+#### Example git-chglog
+`docker run -it --rm -v "$PWD:/data" binbash/git-chglog --init`
+
+Then
+
+`docker run -it --rm -v "$PWD:/data" binbash/git-chglog -o CHANGELOG.md`
+
+### semtag
+Build the docker image using provided Dockerfile and use it directly:
+
+```bash
+export LOCAL_OS_SSH_DIR="~/.ssh"
+export LOCAL_OS_GIT_CONF_DIR="~/.gitconfig"
+
+docker run --rm -v $PWD:/data:rw \
+-v $LOCAL_OS_SSH_DIR:/root/.ssh \
+-v $LOCAL_OS_GIT_CONF_DIR:/etc/gitconfig \
+--entrypoint=/opt/semtag/semtag/semtag \
+-it binbash/git-release
+```
+
+**NOTE:** Alternatively create an alias in your ~/.bashrc with the command presented above.
+
+#### Example semtag
+```bash
+export LOCAL_OS_SSH_DIR="~/.ssh"
+export LOCAL_OS_GIT_CONF_DIR="~/.gitconfig"
+
+docker run --rm -v $PWD:/data:rw \
+-v $LOCAL_OS_SSH_DIR:/root/.ssh \
+-v $LOCAL_OS_GIT_CONF_DIR:/etc/gitconfig \
+--entrypoint=/opt/semtag/semtag/semtag \
+-it binbash/git-release get
+```
+
+### Example composing both binaries in a `Makefile`
+
+```makefile
+.PHONY: help
+SHELL := /bin/bash
+LOCAL_OS_USER := $(shell whoami)
+LOCAL_OS_SSH_DIR := ~/.ssh
+LOCAL_OS_GIT_CONF_DIR := ~/.gitconfig
+
+PWD_DIR := $(shell pwd)
+
+# pre-req -> https://github.com/pnikosis/semtag
+define GIT_SEMTAG_CMD_PREFIX
+docker run --rm \
+-v ${PWD_DIR}:/data:rw \
+-v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
+-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
+--entrypoint=/opt/semtag/semtag/semtag \
+-it binbash/git-release
+endef
+
+GIT_SEMTAG_VER := $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s minor)
+
+help:
+	@echo 'Available Commands:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+release: ## releasing based on semantic tagging script for Git
+	# pre-req -> https://github.com/pnikosis/semtag
+	${GIT_SEMTAG_CMD_PREFIX} --version
+	${GIT_SEMTAG_CMD_PREFIX} get
+	${GIT_SEMTAG_CMD_PREFIX} final -s minor
+
+changelog-init: ## git changelog (https://github.com/git-chglog/git-chglog) config initialization -> ./.chglog
+	@if [ ! -d ./.chglog ]; then\
+		docker run --rm -v ${PWD_DIR}:/data -it binbash/git-release --init;\
+		sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog;\
+    else\
+		echo "==============================";\
+    	echo "git-chglog already initialized";\
+    	echo "==============================";\
+    	echo "$$(ls ./.chglog)";\
+    	echo "==============================";\
+    fi
+
+changelog: ## git changelog (https://github.com/git-chglog/git-chglog)
+	docker run --rm -v ${PWD_DIR}:/data -it binbash/git-release -o CHANGELOG.md --next-tag ${GIT_SEMTAG_VER}
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog
+```

--- a/git-release/README.md
+++ b/git-release/README.md
@@ -61,7 +61,7 @@ docker run --rm -v $PWD:/data:rw \
 -it binbash/git-release get
 ```
 
-### Example composing both binaries in a `Makefile`
+### Example composing both `git-chglog` & `semtag` in a `Makefile`
 
 ```makefile
 .PHONY: help
@@ -109,4 +109,5 @@ changelog-init: ## git changelog (https://github.com/git-chglog/git-chglog) conf
 changelog: ## git changelog (https://github.com/git-chglog/git-chglog)
 	docker run --rm -v ${PWD_DIR}:/data -it binbash/git-release -o CHANGELOG.md --next-tag ${GIT_SEMTAG_VER}
 	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog
+    sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./CHANGELOG.md
 ```


### PR DESCRIPTION
## Updating <img src="https://avatars1.githubusercontent.com/u/31255874?s=280&v=4" alt="binbash" width="40"/> public-docker-images repo:

<div align="middle">
  <img src="https://deploybot.com/assets/blog/Using-Docker-Containersposting.png" alt="docker" width="200"/>
</div>

#### Adding dockerized `git-release` to be used in cross-project modules `Makefiles` to automate and standardize the release tagging.  

###  :notebook: Summary 
1. Since the need of generating consistent cross-project versioning tagging we've decided to automate them in our `Makefile` based on very valuable @diego-ojeda-binbash comment.
```
OJ [6:56 PM]
@Exequiel Barrirero @marcos.pagnucco un par de tools interesantes para implementar en nuestros desarrollos y en las apps de los clientes:

https://github.com/terraform-aws-modules/terraform-aws-redshift/blob/master/Makefile
Makefile
```.PHONY: changelog release

changelog:
    git-chglog -o CHANGELOG.md --next-tag `semtag final -s minor -o````

terraform-aws-modules/terraform-aws-redshift | Added by GitHub
para generar el changelog y para taggear los releases usando semver
```

2. Some small update in the root context README.md file has been done too.

### :checkered_flag: Doc and imple in this same repo can be found at:
* https://github.com/binbashar/public-docker-images/tree/BBL-33-billing-review/git-release
* https://github.com/binbashar/public-docker-images/blob/BBL-33-billing-review/Makefile

### :man_technologist:  New Commits 
- Adding new git-release docker file w/ git-chglog and semtag support
- Updating readme.mds
- readme code block indentation

### :triangular_flag_on_post:  Post Tasks
- Verify successful Docker-Hub autobuild -> https://cloud.docker.com/u/binbash/repository/docker/binbash/git-release/builds
- Effectively test the `make changelog` action from `master` branch. 