### PR TITLE
Updating terraform-resources Makefile in order to test different bina…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
-    <img src="https://binbashar.github.io/public-docker-images/figures/binbash.png" alt="drawing" width="350"/>
+    <img src="https://github.com/binbashar/public-docker-images/blob/master/figures/binbash.png" alt="drawing" width="350"/>
 </div>
 <div align="right">
-  <img src="https://binbashar.github.io/public-docker-images/figures/binbash-leverage-docker.png" alt="leverage" width="230"/>
+  <img src="https://github.com/binbashar/public-docker-images/blob/master/figures/binbash-leverage-docker.png" alt="leverage" width="230"/>
 </div>
 
 # public-docker-images

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
-    <img src="https://github.com/binbashar/public-docker-images/blob/master/figures/binbash.png" alt="drawing" width="350"/>
+    <img src="https://raw.githubusercontent.com/binbashar/public-docker-images/master/figures/binbash.png" alt="drawing" width="350"/>
 </div>
 <div align="right">
-  <img src="https://github.com/binbashar/public-docker-images/blob/master/figures/binbash-leverage-docker.png" alt="leverage" width="230"/>
+  <img src="https://raw.githubusercontent.com/binbashar/public-docker-images/master/figures/binbash-leverage-docker.png" alt="leverage" width="230"/>
 </div>
 
 # public-docker-images

--- a/terraform-resources/Makefile
+++ b/terraform-resources/Makefile
@@ -11,5 +11,21 @@ build: ## build docker image
 build-no-cache: ## build docker image no cache
 	docker build --no-cache -t binbash/terraform-resources:${DOCKER_TAG} -t binbash/terraform-resources:latest --build-arg TERRAFORM_VERSION='${DOCKER_TAG}' .
 
+run-go-version: ## docker run go version
+	docker run -it --rm binbash/terraform-resources:0.11.14 version
+	docker run -it --rm binbash/terraform-resources:0.12.3 version
+
+run-go-env: ## docker run go env
+	docker run -it --rm binbash/terraform-resources:0.11.14 env
+	docker run -it --rm binbash/terraform-resources:0.12.3 env
+
+run-dep-version: ## docker run dep version
+	docker run -it --rm --entrypoint=dep binbash/terraform-resources:0.11.14 version
+	docker run -it --rm --entrypoint=dep binbash/terraform-resources:0.12.3 version
+
+run-terraform-version: ## docker run terraform --version
+	docker run -it --rm --entrypoint=/usr/local/go/bin/terraform binbash/terraform-resources:0.11.14 --version
+	docker run -it --rm --entrypoint=/usr/local/go/bin/terraform binbash/terraform-resources:0.12.3 --version
+
 push: ## push docker image to registry
 	docker push binbash/terraform-resources:${DOCKER_TAG}  && docker push binbash/terraform-resources:latest


### PR DESCRIPTION
## Updating <img src="https://avatars1.githubusercontent.com/u/31255874?s=280&v=4" alt="binbash" width="40"/> public-docker-images repo:

<div align="middle">
  <img src="https://deploybot.com/assets/blog/Using-Docker-Containersposting.png" alt="docker" width="200"/>
</div>

###  :notebook: Summary 
1.Adding new commands to **terraform-resources** `Makefile` in order to validate the different binaries provisioned in this image -> `dep`, `go`, `terraform`.
```
run-go-version: ## docker run go version
	docker run -it --rm binbash/terraform-resources:0.11.14 version
	docker run -it --rm binbash/terraform-resources:0.12.3 version

run-go-env: ## docker run go env
	docker run -it --rm binbash/terraform-resources:0.11.14 env
	docker run -it --rm binbash/terraform-resources:0.12.3 env

run-dep-version: ## docker run dep version
	docker run -it --rm --entrypoint=dep binbash/terraform-resources:0.11.14 version
	docker run -it --rm --entrypoint=dep binbash/terraform-resources:0.12.3 version

run-terraform-version: ## docker run terraform --version
	docker run -it --rm --entrypoint=/usr/local/go/bin/terraform binbash/terraform-resources:0.11.14 --version
	docker run -it --rm --entrypoint=/usr/local/go/bin/terraform binbash/terraform-resources:0.12.3 --version
```


### :man_technologist:  New Commits 
- 4745c37 - Updating terraform-resources Makefile in order to test different binaries
- 790c789 - fixing public figure url

### :triangular_flag_on_post:  Post Tasks
- Verify successful Docker-Hub autobuild -> https://cloud.docker.com/u/binbash/repository/docker/binbash
-  Release new version `make release-patch` and `make changelog-patch` action from `master` branch. 