### PR TITLE
BBL-101 updating mysql-client based image version to a fix one

### DIFF
--- a/mysql-client/Dockerfile
+++ b/mysql-client/Dockerfile
@@ -1,7 +1,7 @@
-FROM debian:stretch-slim
+FROM debian:stretch-20190812-slim
 
 ENV MYSQL_MAJOR 8.0
-ENV MYSQL_VERSION 8.0.16-2debian9
+ENV MYSQL_VERSION 8.0.17-1debian9
 
 RUN echo "deb http://repo.mysql.com/apt/debian/ stretch mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list
 RUN apt-get update && apt-get install -y --allow-unauthenticated mysql-community-client="${MYSQL_VERSION}"


### PR DESCRIPTION
### :man_technologist:  New Commits 
- 8a08806 - BBL-101 updating mysql-client based image version to a fix one

### :triangular_flag_on_post:  Post Tasks
- Verify successful Docker-Hub autobuild 
  - https://cloud.docker.com/u/binbash/repository/docker/binbash/mysql-client/builds
-  Release new version `make release-patch` and `make changelog-patch` action from `master` branch (follow new doc -> https://binbash.atlassian.net/wiki/spaces/BDPS/pages/330432525/e.+Releases+and+versioning)

