### PR TITLE
Support Terraform v0.13.0

### DIFF
--- a/terraform-awscli/Dockerfile
+++ b/terraform-awscli/Dockerfile
@@ -1,4 +1,4 @@
-FROM binbash/terraform-resources:0.12.28
+FROM binbash/terraform-resources:0.13.0
 
 MAINTAINER Binbash Leverage (info@binbash.com.ar)
 

--- a/terraform-awscli/Makefile
+++ b/terraform-awscli/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build
-DOCKER_TAG = 0.12.28
+DOCKER_TAG = 0.13.0
 DOCKER_IMG_NAME = terraform-awscli
 
 LOCAL_OS_USER := $(shell whoami)

--- a/terraform-resources/Makefile
+++ b/terraform-resources/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build
-DOCKER_TAG = 0.12.28
+DOCKER_TAG = 0.13.0
 DOCKER_TAG_TF_0.11 = 0.11.14
 DOCKER_IMG_NAME = terraform-resources
 


### PR DESCRIPTION
## what
* Use latest Terraform version: v0.13.0

## why
* We need it to support count and for_each in modules
