### PR TITLE
Add oathtool to Terraform slim image

### DIFF
--- a/terraform-awscli-slim/Dockerfile
+++ b/terraform-awscli-slim/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex && \
         tree \
         tzdata \
         jq \
+        oath-toolkit-oathtool \
         python3
 RUN rm /var/cache/apk/*
 


### PR DESCRIPTION
## what
* Add oathtool to Terraform slim image

## why
* oathtool is need to avoid prompting the user for the TOTP using the MFA approach
