### PR TITLE
Update Terraform Slim images to use Terraform 0.13.2 as default

### DIFF
--- a/terraform-awscli-slim/Dockerfile
+++ b/terraform-awscli-slim/Dockerfile
@@ -1,4 +1,4 @@
-ARG TERRAFORM_VERSION=0.13.0
+ARG TERRAFORM_VERSION=0.13.2
 FROM hashicorp/terraform:${TERRAFORM_VERSION}
 
 LABEL vendor="Binbash Leverage (info@binbash.com.ar)"

--- a/terraform-awscli-slim/Makefile
+++ b/terraform-awscli-slim/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build
 DOCKER_IMG_NAME = terraform-awscli-slim
-DOCKER_IMG_TAG = 0.13.0
+DOCKER_IMG_TAG = 0.13.2
 
 help:
 	@echo 'Available Commands:'

--- a/terraform-awscli-terratest-slim/Dockerfile
+++ b/terraform-awscli-terratest-slim/Dockerfile
@@ -1,4 +1,4 @@
-ARG TERRAFORM_VERSION=0.13.0
+ARG TERRAFORM_VERSION=0.13.2
 FROM binbash/terraform-awscli-slim:${TERRAFORM_VERSION}
 
 LABEL vendor="Binbash Leverage (info@binbash.com.ar)"

--- a/terraform-awscli-terratest-slim/Makefile
+++ b/terraform-awscli-terratest-slim/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build
 DOCKER_IMG_NAME = terraform-awscli-terratest-slim
-DOCKER_IMG_TAG = 0.13.0
+DOCKER_IMG_TAG = 0.13.2
 
 help:
 	@echo 'Available Commands:'


### PR DESCRIPTION
## what
* Set version 0.13.2 as the default Terraform version supported by Leverage

## why
* We completed the effort to refactor Terraform Makefiles to use a separate config file for non-backend entries
* Now we are ready to adopt Terraform 0.13.2 by testing all layers before we can use that as the default version
