### PR TITLE
Fix | change ubuntu image for circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   #
   build-and-test:
     machine:
-      image: ubuntu-1604:202007-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
+      image: ubuntu-2204:2023.02.1
 
       # This job has been blocked because Docker Layer Caching is not available on your plan.
       # Should upgrade if necessary.


### PR DESCRIPTION
## what
There was an error in circle ci pipeline because was trying to pull an old image of Ubunto